### PR TITLE
Fix PackageManager crashes w/ queryIntent using callerUID of 0

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -8017,7 +8017,8 @@ public class PackageManagerService extends IPackageManager.Stub {
                     (flags & PackageManager.MATCH_DEFAULT_ONLY) != 0, userId);
             // Remove protected Application components
             int callingUid = Binder.getCallingUid();
-            List<String> packages = Arrays.asList(getPackagesForUid(callingUid));
+            String[] pkgs = getPackagesForUid(callingUid);
+            List<String> packages = (pkgs != null) ? Arrays.asList(pkgs) : Collections.EMPTY_LIST;
             if (callingUid != Process.SYSTEM_UID &&
                     (getFlagsForUid(callingUid) & ApplicationInfo.FLAG_SYSTEM) == 0) {
                Iterator<ResolveInfo> itr = list.iterator();


### PR DESCRIPTION
This will fix MonkeyRunner

Change-Id: I7b455607539bb9eab51f19b114e8047731bc0eca
